### PR TITLE
[exporter/awss3exporter] Remove X-Amz-Content-Sha256 header from request

### DIFF
--- a/exporter/awss3exporter/s3_writer.go
+++ b/exporter/awss3exporter/s3_writer.go
@@ -45,7 +45,6 @@ func (lt *RecalculateV4Signature) RoundTrip(req *http.Request) (*http.Response, 
 		return nil, err
 	}
 	req.Header.Set("Accept-Encoding", val)
-	req.Header.Del("X-Amz-Content-Sha256")
 
 	fmt.Println("\n\nAfterAdjustment")
 	rrr, _ := httputil.DumpRequest(req, false)


### PR DESCRIPTION
This change further refines the header management in the `RecalculateV4Signature` middleware by removing the `X-Amz-Content-Sha256` header, ensuring compliance with signing requirements for AWS V4 signatures.

