### PR TITLE
[exporter/awss3exporter] Enhance S3 upload logging

### DIFF
--- a/exporter/awss3exporter/internal/upload/writer.go
+++ b/exporter/awss3exporter/internal/upload/writer.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -54,6 +56,14 @@ func (sw *s3manager) Upload(ctx context.Context, data []byte) error {
 	}
 
 	now := clock.Now(ctx)
+	fmt.Printf("\n\n SW Struct =======> \n%#v\n", sw)
+	key := sw.builder.Build(now)
+	fmt.Println("Uploading to S3 key:", key)
+	if strings.Contains(key, "%3D") {
+		fmt.Println("⚠️ Key is URL-encoded! This will break GCS signature validation.")
+	}
+	fmt.Printf("S3 PutObjectInput:\nBucket: %s\nKey: %s\nContentEncoding: %s\nStorageClass: %s\n",
+		sw.bucket, key, encoding, string(sw.storageClass))
 
 	_, err = sw.uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:          aws.String(sw.bucket),


### PR DESCRIPTION
This commit adds detailed logging to the S3 upload process, including the constructed S3 key and a warning for URL-encoded keys that may affect GCS signature validation. This enhancement aims to improve debugging and monitoring of S3 uploads.