### PR TITLE
[exporter/awss3exporter] Refactor partition key formatting in S3 upload

### DIFF
--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -45,15 +45,16 @@ type PartitionKeyBuilder struct {
 }
 
 func (pki *PartitionKeyBuilder) Build(ts time.Time) string {
+	fmt.Printf("\n\n KEY BUILDER ====> ", pki.bucketKeyPrefix(ts), "/", pki.fileName())
 	return pki.bucketKeyPrefix(ts) + "/" + pki.fileName()
 }
 
 func (pki *PartitionKeyBuilder) bucketKeyPrefix(ts time.Time) string {
-	key := fmt.Sprintf("year=%d/month=%02d/day=%02d/hour=%02d", ts.Year(), ts.Month(), ts.Day(), ts.Hour())
+	key := fmt.Sprintf("%d/%02d/%02d/%02d", ts.Year(), ts.Month(), ts.Day(), ts.Hour())
 
 	switch pki.PartitionTruncation {
 	case "minute":
-		key += "/" + fmt.Sprintf("minute=%02d", ts.Minute())
+		key += "/" + fmt.Sprintf("%02d", ts.Minute())
 	default:
 		// Nothing to do, key defaults to hourly
 	}


### PR DESCRIPTION
This commit modifies the `Build` and `bucketKeyPrefix` methods in the `PartitionKeyBuilder` to streamline the formatting of the S3 partition key. The changes include removing the "year=", "month=", "day=", and "hour=" labels for a more concise key structure, and adding a debug print statement to aid in logging the constructed key during the build process.

