### PR TITLE
[exporter/awss3exporter] Remove debug print statements

### DIFF
--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -45,7 +45,6 @@ type PartitionKeyBuilder struct {
 }
 
 func (pki *PartitionKeyBuilder) Build(ts time.Time) string {
-	fmt.Printf("\n\n KEY BUILDER ====> ", pki.bucketKeyPrefix(ts), "/", pki.fileName())
 	return pki.bucketKeyPrefix(ts) + "/" + pki.fileName()
 }
 

--- a/exporter/awss3exporter/internal/upload/writer.go
+++ b/exporter/awss3exporter/internal/upload/writer.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -56,14 +54,6 @@ func (sw *s3manager) Upload(ctx context.Context, data []byte) error {
 	}
 
 	now := clock.Now(ctx)
-	fmt.Printf("\n\n SW Struct =======> \n%#v\n", sw)
-	key := sw.builder.Build(now)
-	fmt.Println("Uploading to S3 key:", key)
-	if strings.Contains(key, "%3D") {
-		fmt.Println("⚠️ Key is URL-encoded! This will break GCS signature validation.")
-	}
-	fmt.Printf("S3 PutObjectInput:\nBucket: %s\nKey: %s\nContentEncoding: %s\nStorageClass: %s\n",
-		sw.bucket, key, encoding, string(sw.storageClass))
 
 	_, err = sw.uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:          aws.String(sw.bucket),

--- a/exporter/awss3exporter/s3_writer.go
+++ b/exporter/awss3exporter/s3_writer.go
@@ -5,9 +5,7 @@ package awss3exporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"net/http/httputil"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -46,9 +44,6 @@ func (lt *RecalculateV4Signature) RoundTrip(req *http.Request) (*http.Response, 
 	}
 	req.Header.Set("Accept-Encoding", val)
 
-	fmt.Println("\n\nAfterAdjustment")
-	rrr, _ := httputil.DumpRequest(req, false)
-	fmt.Println(string(rrr))
 	return lt.next.RoundTrip(req)
 }
 


### PR DESCRIPTION
This commit cleans up the S3 upload and partition key builder by removing unnecessary debug print statements. The changes enhance code clarity and maintainability without affecting functionality.

